### PR TITLE
Safer way to use regexps

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,6 +91,8 @@ module.exports = postcss.plugin('postcss-colour-functions', function myplugin(op
                 for (var i in functions) {
                     if (val.indexOf(i) !== -1) {
                         var regex = new RegExp(i+"\\([a-zA-Z0-9\\)\\.\\#\\,\\s\\%]+");
+                        var match = val.match(regex);
+                        if (!match) continue;
                         
                         requestedFunction = {
                             'function': i,


### PR DESCRIPTION
Right now plugin has a problem in:

```css
transition: opacity
```

Related issue: https://github.com/postcss/sugarss/issues/53

This changes will fix this issue